### PR TITLE
重複部分の共通化

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,10 +1,13 @@
 class PostsController < ApplicationController
+
+  before_action :set_post, only: %i[show edit update destroy]
+
   def index
     @posts = Post.order(id: :asc)
   end
 
   def show
-    @post = Post.find(params[:id])
+    
   end
 
   def new
@@ -18,26 +21,25 @@ class PostsController < ApplicationController
 
   def edit
 
-    @post = Post.find(params[:id])
-
   end
 
   def update
-
-    post = Post.find(params[:id])
-    post.update!(post_params)
+    @post.update!(post_params)
     redirect_to post
   end
 
   def destroy
-
-    post = Post.find(params[:id])
-    post.destroy!
+    
+    @post.destroy!
     redirect_to root_path
 
   end
 
   private
+
+  def set_post
+    @post = Post.find(params[:id])
+  end
 
   def post_params
     params.require(:post).permit(:title, :content)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,8 +11,7 @@
   </head>
 
   <body>
-    <%= link_to "投稿一覧 ", posts_path %><%= link_to "新規投稿", new_post_path %>
-    <hr>
-    <%= yield %>
+      <%= render "layouts/header" %>
+      <%= yield %>
   </body>
 </html>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,0 +1,13 @@
+<%= form_with model: @post do |form| %>
+  <div>
+    <%= form.label :title, "タイトル" %>
+    <%= form.text_field :title %>
+  </div>
+  <div>
+    <%= form.label :content, "内容" %>  
+    <%= form.text_area :content %>
+  </div>
+  <div>
+    <%= form.submit value %>
+  </div>
+<% end %>

--- a/app/views/posts/_header.html.erb
+++ b/app/views/posts/_header.html.erb
@@ -1,0 +1,2 @@
+<%= link_to "投稿一覧 ", posts_path %><%= link_to "新規投稿", new_post_path %>
+<hr>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,14 +1,2 @@
 <h1>編集</h1>
-<%= form_with model: @post do |form| %>
-  <div>
-    <%= form.label :title, "タイトル" %>
-    <%= form.text_field :title %>
-  </div>
-  <div>
-    <%= form.label :content, "内容" %>  
-    <%= form.text_area :content %>
-  </div>
-  <div>
-    <%= form.submit "送信" %>
-  </div>
-<% end %>
+<% render "form" , post: @post, value: "更新" %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,14 +1,3 @@
 <h1>新規投稿</h1>
-<%= form_with model: @post do |form|%>
-<div>
-<%= form.label :title, "タイトル" %>
-<%= form.text_field :title%>
-</div>
-<div>
-<%= form.label :content, "内容" %>
-<%= form.text_area :content %>
-</div>
-<div>
-<%= form.submit "送信" %>
-</div>
-<% end %>
+<% render "form" %>
+<%= render "form", post: @post, value: "投稿" %>


### PR DESCRIPTION
# コントローラーの処理をbefore_actionで共通化
- posts_controller.rbの　`@post = Post.find(params[:id]) `を共通化しました。

# 投稿ページ部分テンプレートで共通化しました
- _form.html.erb.ファイルを作成し共通部分をそのファイルを読み込むように変更しました。

# ヘッダー部分の共通化
- application.html.erbのリンク部分を_header.html.rrbに切り出すことに変更しました。